### PR TITLE
Better support for show names with apostrophes

### DIFF
--- a/sickbeard/show_name_helpers.py
+++ b/sickbeard/show_name_helpers.py
@@ -135,7 +135,10 @@ def allPossibleShowNames(show, season=-1):
         showNames = get_scene_exceptions(show.indexerid, season=season)
 
     showNames.append(show.name)
-
+    # Show names with an apostrophe may be uploaded with it omitted.
+    if "'" in show.name:
+        showNames.append(show.name.replace("'", ""))
+    
     if not show.is_anime:
         newShowNames = []
         country_list = common.countryList


### PR DESCRIPTION
Proposed changes in this pull request:
- Try searching for show names like "RuPaul's Drag Race" also without the apostrophe character; "RuPauls Drag Race".
